### PR TITLE
Wrong exception object was used

### DIFF
--- a/modules_app/api/handlers/BaseHandler.cfc
+++ b/modules_app/api/handlers/BaseHandler.cfc
@@ -164,7 +164,7 @@ component extends="coldbox.system.EventHandler"{
 		log.error( 
 			"Error in base handler (#arguments.faultAction#): #arguments.exception.message# #arguments.exception.detail#", 
 			{
-				"stacktrace" : e.stacktrace,
+				"stacktrace" : exception.stacktrace,
 				"httpData" : getHTTPRequestData()
 			} 
 		);


### PR DESCRIPTION
The `OnError()` function was trying to log the exception using the object `e` when the argument was actually `exception`.