### PR TITLE
Added event argument "faultAction"

### DIFF
--- a/tests/specs/integration/EchoTests.cfc
+++ b/tests/specs/integration/EchoTests.cfc
@@ -40,7 +40,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root"{
 			});
 
 			it( "can handle invalid HTTP Calls", function(){
-				var event = execute( event="v1:echo.onInvalidHTTPMethod", renderResults = true );
+				var event = execute( event="v1:echo.onInvalidHTTPMethod", renderResults = true, eventArguments = { faultAction = "test" } );
 				var response = event.getPrivateValue( "response" );
 				expect(	response.getError() ).toBeTrue();
 				expect(	response.getStatusCode() ).toBe( 405 );


### PR DESCRIPTION
`onInvalidHTTPMethod()` needs an event argument `faultAction`.  If you execute the event without this argument you'll get a 500 error instead of the expected 405.  Tested on ACF 2016.