### PR TITLE
Made logout function secured to avoid 500 errors

### DIFF
--- a/modules_app/api/modules_app/v1/handlers/Auth.cfc
+++ b/modules_app/api/modules_app/v1/handlers/Auth.cfc
@@ -63,7 +63,7 @@ component extends="coldbox.system.RestHandler" {
 	 * @response-default ~api/v1/auth/logout/responses.json##200
 	 * @response-500 ~api/v1/auth/logout/responses.json##500
 	 */
-	function logout( event, rc, prc ) {
+	function logout( event, rc, prc ) secured {
 		jwtAuth().logout();
 		event.getResponse().addMessage( "Successfully logged out" )
 	}


### PR DESCRIPTION
The logout function should return 401s if called when not logged in.  I rely on this behavior to have axios redirect to a login page.  Without the secured annotation on the logout function in Auth handler, however, calling logout returns 500 error instead of 401.  I believe this is a bug that should be fixed, but this temporary workaround solves the problem.   

More info here: https://boxteam.slack.com/archives/C0532LKQ3/p1606135832229200
And here: https://ortussolutions.atlassian.net/browse/BOX-91