### PR TITLE
Updating mock user properties to correct getters

### DIFF
--- a/models/UserService.cfc
+++ b/models/UserService.cfc
@@ -51,10 +51,10 @@ component accessors="true" singleton {
 
 		variables.mockUsers.append( {
 			"id"       : arguments.user.getId(),
-			"fname"    : arguments.user.getId(),
-			"lname"    : arguments.user.getId(),
-			"email"    : arguments.user.getId(),
-			"password" : arguments.user.getId(),
+			"fname"    : arguments.user.getFname(),
+			"lname"    : arguments.user.getLname(),
+			"email"    : arguments.user.getEmail(),
+			"password" : arguments.user.getPassword(),
 			
 		} );
 		return arguments.user;


### PR DESCRIPTION
Just an update of the mock user to the correct getters so the right information is returned in the auth.register example. 