### PR TITLE
Aligning EchoTest with correct response

### DIFF
--- a/tests/specs/integration/EchoTests.cfc
+++ b/tests/specs/integration/EchoTests.cfc
@@ -80,7 +80,7 @@ component
 				var event    = this.request( "/api/v1/echo/bogus" );
 				var response = event.getPrivateValue( "response" );
 				expect( response.getError() ).tobeTrue();
-				expect( response.getStatusCode() ).toBe( 405 );
+				expect( response.getStatusCode() ).toBe( 404 );
 			} );
 		} );
 	}


### PR DESCRIPTION
CB 6.8 changed the 405 from a missing route to a 404. This test didn't reflect that.